### PR TITLE
Pre-cache actor values

### DIFF
--- a/minai_plugin/test_allequipments.php
+++ b/minai_plugin/test_allequipments.php
@@ -26,35 +26,11 @@ $db = new sql();
 $GLOBALS['db'] = $db;
 $HERIKA_NAME = "Herika";
 
+require_once("test_common.php");
+
 require_once("util.php");
 require_once("wornequipment.php");
 
-
-function assertTrue($expression, $message = "Failed assertion") {
-  if (!$expression) {
-    throw new Exception($message);
-  }
-}
-
-function assertString($expected, $actual, $message = "Failed assertion") {
-  if ($expected != $actual) {
-    print_r("\nExpected: $expected");
-    print_r("\nActual  : $actual");
-    print("\n");
-    throw new Exception($message);
-  }
-}
-
-function assertObjectAsJson($expected, $actual, $message = "Failed assertion") {
-  $expectedStr = json_encode($expected);
-  $actualStr = json_encode($actual);
-  if ($expectedStr != $actualStr) {
-    print_r("\nExpected: $expectedStr");
-    print_r("\nActual  : $actualStr");
-    print("\n");
-    throw new Exception($message);
-  }
-}
 
 function parse_valid_encoded_string_correctly_test() {
   print("parse_valid_encoded_string_correctly_test: ");

--- a/minai_plugin/test_common.php
+++ b/minai_plugin/test_common.php
@@ -1,0 +1,29 @@
+<?php
+
+function assertTrue($expression, $message = "Failed assertion") {
+  if (!$expression) {
+    throw new Exception($message);
+  }
+}
+
+function assertString($expected, $actual, $message = "Failed assertion") {
+  if ($expected != $actual) {
+    print_r("\nExpected: $expected");
+    print_r("\nActual  : $actual");
+    print("\n");
+    throw new Exception($message);
+  }
+}
+
+function assertObjectAsJson($expected, $actual, $message = "Failed assertion") {
+  $expectedStr = json_encode($expected);
+  $actualStr = json_encode($actual);
+  if ($expectedStr != $actualStr) {
+    print_r("\nExpected: $expectedStr");
+    print_r("\nActual  : $actualStr");
+    print("\n");
+    throw new Exception($message);
+  }
+}
+
+?>

--- a/minai_plugin/test_common.php
+++ b/minai_plugin/test_common.php
@@ -6,6 +6,12 @@ function assertTrue($expression, $message = "Failed assertion") {
   }
 }
 
+function assertFalse($expression, $message = "Failed assertion") {
+  if ($expression) {
+    throw new Exception($message);
+  }
+}
+
 function assertString($expected, $actual, $message = "Failed assertion") {
   if ($expected != $actual) {
     print_r("\nExpected: $expected");

--- a/minai_plugin/test_utils.php
+++ b/minai_plugin/test_utils.php
@@ -29,33 +29,68 @@ $HERIKA_NAME = "Herika";
 require_once("test_common.php");
 require_once("util.php");
 
-function stores_cache_key_correctly() {
-    print("stores_cache_key_correctly: ");
-    SetRequestScopeCache("store_cache_key", "store_cache_key_key", "store_cache_key_value");
-    assertString("store_cache_key_value", $GLOBALS[MINAI_CACHE_KEY]["store_cache_key//store_cache_key_key"], "Incorrectly store cache");
+Function has_actor_value_cache_test() {
+    print("has_actor_value_cache_test: ");
+    $name = uniqid();
+    $GLOBALS[MINAI_ACTOR_VALUE_CACHE][$name]['key1'] = "test value";
+
+    assertTrue(HasActorValueCache($name, "key1"), "doesn't have actor value cache");
+    assertTrue(HasActorValueCache($name), "doesn't have actor value cache");
+    assertFalse(HasActorValueCache($name, "key2"), "has actor value cache");
+    assertFalse(HasActorValueCache("name_not_exist"), "has actor value cache");
+
     print("PASSED\n");
 }
 
-function set_and_get_from_cache_returns_correct_value_test() {
-    print("set_and_get_from_cache_returns_correct_value_test: ");
-    SetRequestScopeCache("name1", "key", "value");
-    assertString("value", GetRequestScopeCache("name1", "key"), "Failed to set and get from cache");
+Function get_cache_value_return_null_if_not_exists_test() {
+    print("get_cache_value_return_null_if_not_exists_test: ");
+    $name = uniqid();
+    $GLOBALS[MINAI_ACTOR_VALUE_CACHE][$name]['key1'] = "test value";
+
+    assertString("test value", GetActorValueCache($name, "key1"), "doesn't return value if exists");
     print("PASSED\n");
 }
 
-function update_again_change_to_different_value_test() {
-    print("update_again_change_to_different_value_test: ");
-    SetRequestScopeCache("name2", "key", "value");
-    assertString("value", GetRequestScopeCache("name2", "key"), "fail to get first value");
+Function get_cache_value_return_null_if_not_exists() {
+    print("get_cache_value_return_null_if_not_exists: ");
+    $name = uniqid();
+    $GLOBALS[MINAI_ACTOR_VALUE_CACHE][$name]['key1'] = "test value";
 
-    SetRequestScopeCache("name2", "key", "value2");
-    assertString("value2", GetRequestScopeCache("name2", "key"), "doesn't update value");
+    assertTrue(GetActorValueCache($name, "key2") === null, "doesn't return null if not exists");
+    assertTrue(GetActorValueCache("name_not_exist", "key") === null, "doesn't return null if not exists");
     print("PASSED\n");
 }
 
-function returns_null_when_key_not_found_test() {
-    print("returns_null_when_key_not_found_test: ");
-    assertTrue(GetRequestScopeCache("name_not_exist", "key") === null, "doesn't return null when key not found");
+Function clean_and_create_test_cache() {
+    $GLOBALS["db"]->execQuery("delete from conf_opts where id like '_minai_test_cache//%'");
+    $GLOBALS["db"]->execQuery("insert into conf_opts (id, value) values ('_minai_test_cache//key1', 'test value')");
+    $GLOBALS["db"]->execQuery("insert into conf_opts (id, value) values ('_minai_test_cache//key2', 'test value2')");
+
+    $GLOBALS["db"]->execQuery("delete from conf_opts where id like '_minai_test//cache//%'");
+    $GLOBALS["db"]->execQuery("insert into conf_opts (id, value) values ('_minai_test//cache//key1', 'test//value')");
+}
+
+Function build_cache_get_value_from_cache_correctly_test() {
+    print("build_cache_get_value_from_cache_correctly_test: ");
+    BuildActorValueCache("test_cache");
+    BuildActorValueCache("test//cache");
+
+    assertString("test value", GetActorValueCache("test_cache", "key1"), "doesn't build cache correctly");
+    assertString("test value2", GetActorValueCache("test_cache", "key2"), "doesn't build cache correctly");
+    assertString("test//value", GetActorValueCache("test//cache", "key1"), "doesn't build cache correctly");
+    assertString(null, GetActorValueCache("test_cache", "key3"), "doesn't build cache correctly");
+    assertString(null, GetActorValueCache("test_cache2", "key1"), "doesn't build cache correctly");
+    print("PASSED\n");
+}
+
+Function get_actor_value_from_cache_test() {
+    print("get_actor_value_from_cache_test: ");
+    $name = uniqid();
+    $GLOBALS[MINAI_ACTOR_VALUE_CACHE][$name]['key1'] = "test value";
+    $GLOBALS[MINAI_ACTOR_VALUE_CACHE][$name]['key2'] = "test value2";
+
+    assertString("test value", GetActorValue($name, "key1"), "doesn't get actor value from cache");
+    assertString("test value2", GetActorValue($name, "key2"), "doesn't get actor value from cache");
     print("PASSED\n");
 }
 
@@ -64,10 +99,13 @@ function returns_null_when_key_not_found_test() {
 <pre>
 
 <?php
-stores_cache_key_correctly();
-set_and_get_from_cache_returns_correct_value_test();
-update_again_change_to_different_value_test();
-returns_null_when_key_not_found_test();
+clean_and_create_test_cache();
+
+has_actor_value_cache_test();
+get_cache_value_return_null_if_not_exists_test();
+build_cache_get_value_from_cache_correctly_test();
+get_actor_value_from_cache_test();
+
 ?>
 
 </pre>

--- a/minai_plugin/test_utils.php
+++ b/minai_plugin/test_utils.php
@@ -1,0 +1,73 @@
+<?php
+
+ini_set('display_errors', '1');
+ini_set('display_startup_errors', '1');
+error_reporting(E_ALL);
+
+$configFilepath = __DIR__ . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR . "conf" . DIRECTORY_SEPARATOR;
+$rootEnginePath = __DIR__ . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR;
+
+if (!file_exists($configFilepath . "conf.php")) {
+  @copy($configFilepath . "conf.sample.php", $configFilepath . "conf.php");   // Defaults
+  if (!file_exists($rootEnginePath . "data" . DIRECTORY_SEPARATOR . "mysqlitedb.db")) {
+    require($rootEnginePath . "ui" . DIRECTORY_SEPARATOR . "cmd" . DIRECTORY_SEPARATOR . "install-db.php");
+  }
+  die(header("Location: conf_wizard.php"));
+}
+
+require_once($rootEnginePath . "conf" . DIRECTORY_SEPARATOR . "conf.php");
+require_once($rootEnginePath . "lib" . DIRECTORY_SEPARATOR . "{$GLOBALS["DBDRIVER"]}.class.php");
+
+print("dbdriver: " . $GLOBALS["DBDRIVER"] . "\n");
+
+$GLOBALS['HERIKA_NAME'] = "Herika";
+
+$db = new sql();
+$GLOBALS['db'] = $db;
+$HERIKA_NAME = "Herika";
+
+require_once("test_common.php");
+require_once("util.php");
+
+function stores_cache_key_correctly() {
+    print("stores_cache_key_correctly: ");
+    SetRequestScopeCache("store_cache_key", "store_cache_key_key", "store_cache_key_value");
+    assertString("store_cache_key_value", $GLOBALS[MINAI_CACHE_KEY]["store_cache_key//store_cache_key_key"], "Incorrectly store cache");
+    print("PASSED\n");
+}
+
+function set_and_get_from_cache_returns_correct_value_test() {
+    print("set_and_get_from_cache_returns_correct_value_test: ");
+    SetRequestScopeCache("name1", "key", "value");
+    assertString("value", GetRequestScopeCache("name1", "key"), "Failed to set and get from cache");
+    print("PASSED\n");
+}
+
+function update_again_change_to_different_value_test() {
+    print("update_again_change_to_different_value_test: ");
+    SetRequestScopeCache("name2", "key", "value");
+    assertString("value", GetRequestScopeCache("name2", "key"), "fail to get first value");
+
+    SetRequestScopeCache("name2", "key", "value2");
+    assertString("value2", GetRequestScopeCache("name2", "key"), "doesn't update value");
+    print("PASSED\n");
+}
+
+function returns_null_when_key_not_found_test() {
+    print("returns_null_when_key_not_found_test: ");
+    assertTrue(GetRequestScopeCache("name_not_exist", "key") === null, "doesn't return null when key not found");
+    print("PASSED\n");
+}
+
+?>
+
+<pre>
+
+<?php
+stores_cache_key_correctly();
+set_and_get_from_cache_returns_correct_value_test();
+update_again_change_to_different_value_test();
+returns_null_when_key_not_found_test();
+?>
+
+</pre>

--- a/minai_plugin/util.php
+++ b/minai_plugin/util.php
@@ -1,27 +1,45 @@
 <?php
 require_once("config.php");
-define("MINAI_CACHE_KEY", "minai_cache");
+define("MINAI_ACTOR_VALUE_CACHE", "minai_actor_value_cache");
 
-$GLOBALS[MINAI_CACHE_KEY] = [];
+$GLOBALS[MINAI_ACTOR_VALUE_CACHE] = [];
 
-function CreateCacheKey($name, $key) {
-    return strtolower($name) . "//" . strtolower($key);
-}
-
-// Get the value of request scope cache
-function GetRequestScopeCache($name, $key) {
-    $combinedKey = CreateCacheKey($name, $key);
-    if (isset($GLOBALS[MINAI_CACHE_KEY][$combinedKey])) {
-        return $GLOBALS[MINAI_CACHE_KEY][$combinedKey];
+// Get Value from the cache. $name/$key should be lowercase
+Function GetActorValueCache($name, $key) {
+    if (isset($GLOBALS[MINAI_ACTOR_VALUE_CACHE][$name])
+        && isset($GLOBALS[MINAI_ACTOR_VALUE_CACHE][$name][$key])
+    ) {
+        return $GLOBALS[MINAI_ACTOR_VALUE_CACHE][$name][$key];
     }
     else {
+        // no value in the cache
         return null;
     }
 }
 
-function SetRequestScopeCache($name, $key, $value) {
-    $combinedKey = CreateCacheKey($name, $key);
-    $GLOBALS[MINAI_CACHE_KEY][$combinedKey] = $value;
+// Check if actor value has been cached. $name/$key should be lowercase
+Function HasActorValueCache($name, $key=null) {
+    if ($key === null) {
+        return isset($GLOBALS[MINAI_ACTOR_VALUE_CACHE][$name]);
+    }
+    return isset($GLOBALS[MINAI_ACTOR_VALUE_CACHE][$name]) && isset($GLOBALS[MINAI_ACTOR_VALUE_CACHE][$name][$key]);
+}
+
+Function BuildActorValueCache($name) {
+    $name = strtolower($name);
+    $GLOBALS[MINAI_ACTOR_VALUE_CACHE][$name] = [];
+
+    $idPrefix = "_minai_{$name}//";
+
+    $query = "select * from conf_opts where LOWER(id) like LOWER('{$idPrefix}%')";
+    $ret = $GLOBALS["db"]->fetchAll($query);
+
+    foreach ($ret as $row) {
+        //do this instead of split // because $name could have // in it
+        $key = substr(strtolower($row['id']), strlen($idPrefix));
+        $value = $row['value'];
+        $GLOBALS[MINAI_ACTOR_VALUE_CACHE][$name][$key] = $value;
+    }
 }
 
 function CanVibrate($name) {
@@ -33,13 +51,17 @@ function CanVibrate($name) {
 Function GetActorValue($name, $key, $preserveCase=false, $skipCache=false) {
     $name = addslashes($name);
     $key = addslashes($key);
-    $cacheKey = $key."//{$preserveCase}";
 
-    if (!$skipCache) {
-        $valueFromCache = GetRequestScopeCache($name, $cacheKey);
-        if ($valueFromCache !== null) {
-            return $valueFromCache;
+    If (!$preserveCase && !$skipCache) {
+        $name = strtolower($name);
+        $key = strtolower($key);
+
+        If (!HasActorValueCache($name)) {
+            BuildActorValueCache($name);
         }
+
+        $ret = GetActorValueCache($name, $key);
+        return $ret === null ? "" : $ret;
     }
 
     // return strtolower("JobInnkeeper,Whiterun,,,,Bannered Mare Services,,Whiterun Bannered Mare Faction,,SLA TimeRate,sla_Arousal,sla_Exposure,slapp_HaveSeenBody,slapp_IsAnimatingWKidFaction,");
@@ -53,8 +75,6 @@ Function GetActorValue($name, $key, $preserveCase=false, $skipCache=false) {
         return "";
     }
     $ret = strtolower($ret[0]['value']);
-
-    SetRequestScopeCache($name, $cacheKey, $ret);
     
     return $ret;
 }


### PR DESCRIPTION
Not sure if it's overkill to cache here. 
But this should prevent multiple hit to DB.
Assume that we don't currently update DB and read it again. Otherwise, it may be better to have specific function to GetAllKeywords and cache there instead of cache on GetActorValue