### PR TITLE
moved sex scene context to context file instead of adding only when sextalk on scene change happened

### DIFF
--- a/minai_plugin/context.php
+++ b/minai_plugin/context.php
@@ -347,6 +347,37 @@ if (!$GLOBALS["disable_nsfw"]) {
 ";
 }
 
+// If npc is in sex scene add current scene description to context
+function getSexSceneContext() {
+  $scene = getScene($GLOBALS["HERIKA_NAME"]);
+  if ($scene && is_array($GLOBALS["contextDataFull"]) && $GLOBALS["HERIKA_NAME"] !== "The Narrator") {
+    $prompt = "The Narrator: ";
+    $sceneDesc = $scene["description"];
+    if (!$sceneDesc) {
+      if ($scene["fallback"]) {
+        $sceneDesc = $scene["fallback"];
+      } else {
+        $sceneDesc = "{$scene["actors"]} are having sex.";
+      }
+
+    }
+
+    if (!$scene["prev_scene_id"]) {
+      $prompt .= "{$scene["actors"]} started sex scene.";
+    } else {
+      $prompt .= "{$scene["actors"]} changed position.";
+    }
+    $prompt .= " $sceneDesc #SEX_SCENARIO";
+    $contextItem = [
+      "role"=>"user",
+      "content"=>$prompt
+    ];
+    array_push($GLOBALS["contextDataFull"], $contextItem);
+  }
+}
+
+getSexSceneContext();
+
 // Clean up context
 $locaLastElement=[];
 $narratorElements=[];

--- a/minai_plugin/customintegrations.php
+++ b/minai_plugin/customintegrations.php
@@ -169,28 +169,10 @@ function ProcessIntegrations() {
     if (isset($GLOBALS["gameRequest"]) && str_starts_with(strtolower($GLOBALS["gameRequest"][0]), "sextalk")) {
         $type = $GLOBALS["gameRequest"][0];
         $scene = getScene($GLOBALS["HERIKA_NAME"]);
-        $sceneDesc = $scene["description"];
-        if(!$sceneDesc) {
-            if($scene["fallback"]) {
-                $sceneDesc = $scene["fallback"];
-            } else {
-                $sceneDesc = "{$scene["actors"]} are having sex.";
-            }
-            
-        }
-
         $prompt = "";
 
         switch($type) {
             case "sextalk_scenechange": {
-                $prompt = "The Narrator: ";
-                
-                if(!$scene["prev_scene_id"]) {
-                    $prompt .= "{$scene["actors"]} started sex scene.";
-                } else {
-                    $prompt .= "{$scene["actors"]} changed position.";
-                }
-                $prompt .= " $sceneDesc";
                 break;
             }
             case "sextalk_speedincrease":

--- a/minai_plugin/sexPrompts.php
+++ b/minai_plugin/sexPrompts.php
@@ -35,7 +35,7 @@ if(isset($scene)){
     
     $speakStyle = null;
     if ($jsonXPersonality)
-        $jsonXPersonality["speakStyleDuringSex"];
+        $speakStyle = $jsonXPersonality["speakStyleDuringSex"];
 
     if(!$speakStyle) {
         $speakStyle = $speakStyles[array_rand($speakStyles)];

--- a/minai_plugin/speakStylesPrompts/breathlessGasps.php
+++ b/minai_plugin/speakStylesPrompts/breathlessGasps.php
@@ -1,6 +1,6 @@
 <?php
 
-function setBreathlessGaspsPrompts($currentName, $targetToTalk)
+function setBreathlessGaspsPrompts($currentName)
 {
     $GLOBALS["PROMPTS"]["sextalk_climaxchastity"] = [
         "cue" => [


### PR DESCRIPTION
As discussed, moved logic to add scene description into context to `context.php` instead of adding it only when scene change sexTalk happens(because of sexTalk cooldown it could miss adding sex description context).
Benefits:
- Always correct scene description context;
- Won't pollute context with all previous scene descriptions;
- Won't miss scene context if sextalk was throttled.

Also fixed couple of bugs in php and papyrus