### PR TITLE
Improve BuildEquipmentContext

### DIFF
--- a/minai_plugin/wornequipment.php
+++ b/minai_plugin/wornequipment.php
@@ -139,18 +139,34 @@ function BuildEquipmentContext(&$parsedData)
     $name = $segment['name'];
     $description = $segment['description'];
 
-    if (empty($description)) {
-      $context .= "{$name}, ";
-    } else {
-      $context .= "{$name} - {$description}, ";
+    if (!empty($context)) {
+      $context .= ", ";
     }
 
-    foreach ($segment['keywords'] as $keyword) {
-      $skipKeywords[strtolower($keyword)] = true;
+    if (empty($name)) {
+      if (!empty($description)) {
+        $context .= "{$description}";
+      }
+    } else {
+      if (empty($description)) {
+        $context .= "{$name}";
+      } else {
+        $context .= "{$name} - {$description}";
+      }
+    }
+
+    if (!empty($description)) {
+      foreach ($segment['keywords'] as $keyword) {
+        $skipKeywords[strtolower($keyword)] = true;
+      }
     }
   }
+  
+  if (!empty($context)) {
+    $context .= ". ";
+  }
   return [
-    'context' => $context . ". ",
+    'context' => $context,
     'skipKeywords' => $skipKeywords
   ];
 }


### PR DESCRIPTION
I am not quite sure what to do with skipKeywords, because current code seems to just skip every keyword.

Also, I currently have a few hacks in context.php, because cuirass is not properly reset by papyrus code. Hacked part looks like this:

```
  if (!empty($eqContext["context"])) {
    $ret .= "{$name} is wearing {$eqContext["context"]}";
  } elseif (!IsEnabled($name, "isNaked")) {
    $ret .= "It is hard to say what {$name} is wearing, probably nothing.\n";
  }

  // elseif (!empty($cuirass)) {
  //   $ret .= "{$name} is wearing {$cuirass}.\n";
  // }
  
  if (IsEnabled($name, "isNaked")) {
    $ret .= "{$name} is naked and exposed.\n";
  }
```