### PR TITLE
Update util.php to preserve player name case

### DIFF
--- a/minai_plugin/util.php
+++ b/minai_plugin/util.php
@@ -200,7 +200,7 @@ Function RegisterAction($actionName) {
 
 // Override player name
 if ($GLOBALS["force_aiff_name_to_ingame_name"]) {
-    $playerName = GetActorValue("PLAYER", "playerName");
+    $playerName = GetActorValue("PLAYER", "playerName", true);
     if ($playerName) {
         $GLOBALS["PLAYER_NAME"] = $playerName;
     }


### PR DESCRIPTION
Issue with player's name override, player name is converted to lowercase. If the player's name is a common noun, mentioning the name without a capital letter in the middle of a sentence creates confusion.