### PR TITLE
Update command_prompt_custom.php

### DIFF
--- a/minai_plugin/command_prompt_custom.php
+++ b/minai_plugin/command_prompt_custom.php
@@ -32,6 +32,7 @@ if (IsRadiant()) { // Is this npc -> npc?
         
 }
 else {
+    $GLOBALS["ADD_PLAYER_BIOS"]  = true; //must set true because once false for radiant, remains false for a long time 
     if ($shouldOverride)
         SetPromptHead($GLOBALS["PROMPT_HEAD_OVERRIDE"]);
     else


### PR DESCRIPTION
After a radiant conversation, PLAYER_BIOS is no longer added to the prompt. ADD_PLAYER_BIOS is set to false for radiant conversations and remains that way for a long time. The added line immediately sets ADD_PLAYER_BIOS back to true for non-radiant conversations.