### PR TITLE
Various context fixes

### DIFF
--- a/Scripts/Source/minai_Arousal.psc
+++ b/Scripts/Source/minai_Arousal.psc
@@ -506,7 +506,9 @@ Function SetContext(actor akTarget)
   aiff.SetActorVariable(akTarget, "isnaked", !cuirass)
   aiff.SetActorVariable(akTarget, "arousal", GetActorArousal(akTarget))
   aiff.SetActorVariable(akTarget, "isexposed", IsTNGExposed(akTarget))
-  if cuirass != None
+  if cuirass == None
+    aiff.SetActorVariable(akTarget, "cuirass", "")
+  Else
     aiff.SetActorVariable(akTarget, "cuirass", cuirass.GetName())
   EndIf
   if !bHasArousedKeywords

--- a/minai_plugin/context.php
+++ b/minai_plugin/context.php
@@ -52,7 +52,7 @@ Function GetSurvivalContext($name) {
 Function GetArousalContext($name) {
   $ret = "";
   $arousal = GetActorValue($name, "arousal");
-  if ($arousal != "" && IsModEnabled("Aroused")) {
+  if ($arousal != "" && (IsModEnabled("OSL") || IsModEnabled("Aroused"))) {
       $ret .= "{$name}'s sexual arousal level is {$arousal}/100, where 0 is not aroused at all, and 100 is desperate for sex.";
   }
   if ($ret != "")

--- a/minai_plugin/context.php
+++ b/minai_plugin/context.php
@@ -52,7 +52,7 @@ Function GetSurvivalContext($name) {
 Function GetArousalContext($name) {
   $ret = "";
   $arousal = GetActorValue($name, "arousal");
-  if ($arousal != "") {
+  if ($arousal != "" && IsModEnabled("Aroused")) {
       $ret .= "{$name}'s sexual arousal level is {$arousal}/100, where 0 is not aroused at all, and 100 is desperate for sex.";
   }
   if ($ret != "")

--- a/minai_plugin/context.php
+++ b/minai_plugin/context.php
@@ -147,7 +147,7 @@ Function HasKeywordAndNotSkip($name, $eqContext, $keyword) {
 }
 
 Function GetClothingContext($name) {
-  $cuirass = GetActorValue($name, "cuirass");
+  $cuirass = GetActorValue($name, "cuirass", false, true);
   $ret = "";
   
   $eqContext = GetAllEquipmentContext($name);
@@ -159,11 +159,10 @@ Function GetClothingContext($name) {
   // if $eqContext["context"] not empty, then will set ret
   if (!empty($eqContext["context"])) {
     $ret .= "{$name} is wearing {$eqContext["context"]}";
+  } elseif (IsEnabled($name, "isNaked")) {
+    $ret .= "{$name} is naked and exposed.\n";
   } elseif (!empty($cuirass)) {
     $ret .= "{$name} is wearing {$cuirass}.\n";
-  }
-  elseif (IsEnabled($name, "isNaked")) {
-    $ret .= "{$name} is naked and exposed.\n";
   }
 
   if (HasKeywordAndNotSkip($name, $eqContext, "SLA_HalfNakedBikini")) {

--- a/minai_plugin/util.php
+++ b/minai_plugin/util.php
@@ -335,7 +335,7 @@ function addXPersonality($jsonXPersonality) {
     - Romantic relationship type: {$jsonXPersonality["relationshipStyle"]}";
 
     if(IsSexActive()) {
-        $GLOBALS["HERIKA_PERS"] .= "
+        $GLOBALS["HERIKA_PERS"] = "
 During sex {$GLOBALS["HERIKA_PERS"]}:
 - speaks in this style {$jsonXPersonality["speakStyleDuringSex"]};
 - prefers these positions: ".implode(", ", $jsonXPersonality["preferredSexPositions"]).";

--- a/minai_plugin/util.php
+++ b/minai_plugin/util.php
@@ -424,7 +424,7 @@ function getTargetDuringSex($scene) {
 }
 
 function GetRevealedStatus($name) {
-  $cuirass = GetActorValue($name, "cuirass");
+  $cuirass = GetActorValue($name, "cuirass", false, true);
   
   $wearingBottom = false;
   $wearingTop = false;

--- a/minai_plugin/util.php
+++ b/minai_plugin/util.php
@@ -335,8 +335,8 @@ function addXPersonality($jsonXPersonality) {
     - Romantic relationship type: {$jsonXPersonality["relationshipStyle"]}";
 
     if(IsSexActive()) {
-        $GLOBALS["HERIKA_PERS"] = "
-During sex {$GLOBALS["HERIKA_PERS"]}:
+        $GLOBALS["HERIKA_PERS"] .= "
+During sex {$GLOBALS["HERIKA_NAME"]}:
 - speaks in this style {$jsonXPersonality["speakStyleDuringSex"]};
 - prefers these positions: ".implode(", ", $jsonXPersonality["preferredSexPositions"]).";
 - likes to participate in such sex activities: ".implode(", ", $jsonXPersonality["sexualBehavior"]).";


### PR DESCRIPTION
This PR fixes ~~two~~ three small bugs in context sent to the LLM.
1. Arousal is always set as 0 in the GetActorArousal() papyrus script even if the arousal mod is disabled. The php side seems to expect a blank string if the mod is disabled, not 0, so the arousal text is always added to the context. Fixed by adding a check to see if the mod is enabled when creating the arousal context string.
2. When building the speaker personality context, the string is concatenating itself and becomes duplicated. Fixed by replacing one instance of the bio with the speaker's name (I think that was the original intent).
3. Context is showing that my character is wearing armor in the case that I take it off and then start a scene. Fixed by changing the papyrus script to set cuirass to blank if no armor is found. I also adjusted the php side to give priority to isNaked. And I disallowed cuirass from being checked via cache, since that seemed to be another cause of my armor still showing in context.