### PR TITLE
fix sexlab pplus papyrus errors when building fallback text

### DIFF
--- a/Scripts/Source/minai_SexUtil.psc
+++ b/Scripts/Source/minai_SexUtil.psc
@@ -132,6 +132,8 @@ string function buildSceneString(string sceneId, string actorString, string even
   elseif(eventType == "scenechange")
     return actorString + " changed the scene to " + result
   endif
+
+  return result
 endfunction
 
 actor[] function BuildGroup(int size, int jMalesArr, int jFemalesArr)


### PR DESCRIPTION
1. When building the scene fallback text, sexlab p+ errors on FetchStage causing a lot of papyrus errors. Fixed by skipping the description text when using sexlab p+ and only using the tags - also because sexlab p+ doesn't ship with any animations and so wouldn't have scene descriptions anyway.
2. added a missing return statement to buildSceneString for the case where only tags were available.