### PR TITLE
Support sexlab p+ SLSB climax timing

### DIFF
--- a/Scripts/Source/minai_Sex.psc
+++ b/Scripts/Source/minai_Sex.psc
@@ -1008,16 +1008,20 @@ actor[] Function getClimaxingActorsArray(int ThreadID)
   SexLabThread thread = slf.GetThread(ThreadID)
   string sceneHash = thread.GetActiveScene()
   string stageHash = thread.GetActiveStage()
+  actor[] climaxingActors = PapyrusUtil.ActorArray(0)
+
   ; get the climaxing positions in the scene (0, 1, 2, etc)
   int[] climaxingPositions = SexlabRegistry.GetClimaxingActors(sceneHash, stageHash)
+  If climaxingPositions.Length == 0
+    return climaxingActors
+  EndIf
 
-  actor[] climaxingActors = PapyrusUtil.ActorArray(0)
   actor[] actorsInScene = thread.GetPositions()
   int i = 0
   while i < actorsInScene.Length
     actor currActor = actorsInScene[i]
     ; don't add the player
-    If currActor != PlayerRef
+    If currActor != PlayerRef && thread.IsOrgasmAllowed(currActor)
       ; check if the actor is in one of the climaxing positions
       int actorPosition = thread.GetPositionIdx(currActor)
       If climaxingPositions.Find(actorPosition) >= 0

--- a/Scripts/Source/minai_Sex.psc
+++ b/Scripts/Source/minai_Sex.psc
@@ -684,6 +684,7 @@ Event SLSOOrgasm(Form actorRef, Int tid)
     return
   EndIf
 
+  Main.Debug("[SLSOOrgasm] name = " + actorInAction.GetName() + " tid: " + tid)
   sslThreadController controller = slf.GetController(tid)
   Actor[] actorList = slf.HookActors(tid)
 


### PR DESCRIPTION
When using sexlab p+ "scene" climax type, the climax hook fires right before the scene that triggers it, so that scene's description doesn't get loaded in context for the climax talk. Fixed by detecting if the "scene" climax type is active, and if so skipping the climax hooks and doing the climax sextalk during the scenechange hook.