### PR TITLE
check for some blank faction names

### DIFF
--- a/Scripts/Source/minai_AIFF.psc
+++ b/Scripts/Source/minai_AIFF.psc
@@ -343,10 +343,28 @@ Function StoreFactions(actor akTarget)
   Faction[] factions = akTarget.GetFactions(-128, 127)
   int i = 0
   while i < factions.Length
-   allFactions += factions[i].GetName() + ","
+   string factionName = factions[i].GetName()
+   If factionName == ""
+     factionName = GetVanillaFactionName(factions[i].GetFormID())
+   EndIf
+   If factionName != ""
+     allFactions += factionName + ","
+   EndIf
    i += 1
   EndWhile
   SetActorVariable(akTarget, "AllFactions", allFactions)
+EndFunction
+
+; check for some of the vanilla factions with blank names
+string Function GetVanillaFactionName(int factionId)
+  If factionId == "378957" ; 0005C84D
+    return "PotentialFollowerFaction"
+  ElseIf factionId == "378958" ; 0005C84E
+    return "CurrentFollowerFaction" ; also includes some follower animals like Vigilance not found in PotentialFollowerFaction
+  ElseIf factionId == "33653669" ; 020183A5 (load order dependent, but dawnguard should always be 02)
+    return "DLC1SeranaFaction" ; Serana doesn't join the normal follower factions
+  EndIf
+  return ""
 EndFunction
 
 

--- a/minai_plugin/util.php
+++ b/minai_plugin/util.php
@@ -126,7 +126,14 @@ Function IsConfigEnabled($configKey) {
 }
 
 Function IsFollower($name) {
-    return (IsInFaction($name, "Framework Follower Faction") || IsInFaction($name, "Follower Role Faction") || IsInFaction($name, "PotentialFollowerFaction") || IsInFaction($name, "Potential Follower"));
+    return (
+		IsInFaction($name, "Framework Follower Faction") ||
+		IsInFaction($name, "Follower Role Faction") ||
+		IsInFaction($name, "PotentialFollowerFaction") ||
+		IsInFaction($name, "CurrentFollowerFaction") ||
+		IsInFaction($name, "DLC1SeranaFaction") ||
+		IsInFaction($name, "Potential Follower")
+	);
 }
 
 // Check if the specified actor is following (not follower)

--- a/minai_plugin/util.php
+++ b/minai_plugin/util.php
@@ -127,13 +127,13 @@ Function IsConfigEnabled($configKey) {
 
 Function IsFollower($name) {
     return (
-		IsInFaction($name, "Framework Follower Faction") ||
-		IsInFaction($name, "Follower Role Faction") ||
-		IsInFaction($name, "PotentialFollowerFaction") ||
-		IsInFaction($name, "CurrentFollowerFaction") ||
-		IsInFaction($name, "DLC1SeranaFaction") ||
-		IsInFaction($name, "Potential Follower")
-	);
+        IsInFaction($name, "Framework Follower Faction") ||
+        IsInFaction($name, "Follower Role Faction") ||
+        IsInFaction($name, "PotentialFollowerFaction") ||
+        IsInFaction($name, "CurrentFollowerFaction") ||
+        IsInFaction($name, "DLC1SeranaFaction") ||
+        IsInFaction($name, "Potential Follower")
+    );
 }
 
 // Check if the specified actor is following (not follower)


### PR DESCRIPTION
Many of the vanilla factions only have an editor id and no name, including the follower factions.
Fixed by checking if GetName returned "" and then using the form id of the faction to check for a few specific factions.
This shouldn't affect factions that already have a name.