### PR TITLE
Fix broken Japanese LLM calls when using dirt and blood

### DIFF
--- a/minai_plugin/dirtandblood.php
+++ b/minai_plugin/dirtandblood.php
@@ -16,7 +16,6 @@ class dnb {
         $str = "";
         if(count($someArray)>1) {
             $str = implode(", ", $someArray); 
-            $str = substr($str, 0, -2);
         } else $str = $someArray[0];
         if($hasHave) {
             if($count>1) {


### PR DESCRIPTION
Remove extraneous substr from the `rollUpAList` function used with dirt and blood.

1. It's unnecessary. The substr seems to be used to remove a trailing comma and whitespace, but `implode` does not add the separator to the end of the list.
2. It breaks multi-byte text (Japanese). `substr($str, 0, -2)` in php will remove the last two bytes, not the last two characters. This results in a broken character and leaves a hanging byte in the text, which breaks the POST to the LLM and throws an error.