### PR TITLE
Changes and Fixes for Undress Command

### DIFF
--- a/Scripts/Source/minai_Sex.psc
+++ b/Scripts/Source/minai_Sex.psc
@@ -557,6 +557,10 @@ Event CommandDispatcher(String speakerName,String  command, String parameter)
     while iIndex < iElement
       if devious.HasDD() && equippedItems[iIndex].HasKeyword(devious.libs.zad_Lockable)
         Main.Debug("Not removing " + equippedItems[iIndex] + " - Lockable DD")
+      elseif equippedItems[iIndex].HasKeywordString("OStimNoStrip") || equippedItems[iIndex].HasKeywordString("SexLabNoStrip") ; skip removing any item tagged with OStimNoStrip or SexLabNoStrip
+        Main.Debug("Not removing " + equippedItems[iIndex].GetName() + " - OStimNoStrip or SexLabNoStrip")
+      elseif (equippedItems[iIndex] as Armor) != None && ((equippedItems[iIndex] as Armor).GetSlotMask() == 2 || (equippedItems[iIndex] as Armor).GetSlotMask() == 2050) ; skip removing hair items
+        Main.Debug("Not removing " + equippedItems[iIndex].GetName() + " - Wig")
       else
         Main.Debug("Removing " + equippedItems[iIndex].GetName())
         JArray.AddForm(equippedArmor, equippedItems[iIndex])


### PR DESCRIPTION
Added 2 different checks on the undress logic:

1. Skips stripping any items with the keyword OStimNoStrip or SexLabNoStrip. This will prevent things like the SMP Physics object in slot 50 from being stripped off
2. Skips stripping any item with slot mask 2 (Slot 31 - Hair) or 2050 (Slot 31 - Hair plus Slot 41 - Long Hair). This will prevent stripping of things like KS Wigs