### PR TITLE
Add spaces to hidden_by string on tattoo page

### DIFF
--- a/minai_plugin/tattoo_descriptions.html
+++ b/minai_plugin/tattoo_descriptions.html
@@ -845,7 +845,7 @@
                         <td>${escapeHtml(tattoo.section)}</td>
                         <td>${escapeHtml(tattoo.name)}</td>
                         <td>${escapeHtml(tattoo.description || '')}</td>
-                        <td>${escapeHtml(tattoo.hidden_by || '')}</td>
+                        <td>${escapeHtml(tattoo.hidden_by.replaceAll(',', ', ') || '')}</td>
                         <td class="action-buttons">
                             <button class="edit-button" data-section="${escapeHtml(tattoo.section)}" data-name="${escapeHtml(tattoo.name)}">Edit</button>
                             <button class="delete-button" data-section="${escapeHtml(tattoo.section)}" data-name="${escapeHtml(tattoo.name)}">Delete</button>
@@ -924,7 +924,7 @@
                         <td>${escapeHtml(tattoo.section)}</td>
                         <td>${escapeHtml(tattoo.name)}</td>
                         <td>${escapeHtml(tattoo.description || '')}</td>
-                        <td>${escapeHtml(tattoo.hidden_by || '')}</td>
+                        <td>${escapeHtml(tattoo.hidden_by.replaceAll(',', ', ') || '')}</td>
                         <td title="${escapeHtml(actorsList)}">${actorCount} actor${actorCount !== 1 ? 's' : ''}</td>
                         <td class="action-buttons">
                             <button class="edit-button" data-section="${escapeHtml(tattoo.section)}" data-name="${escapeHtml(tattoo.name)}">Edit</button>


### PR DESCRIPTION
This adds spaces to the list of hidden_by keywords so word wrap works properly. The check box function seems to take care of removing the spaces before submitting, so it would seem as though we don't need to worry about that.

I have no idea what changed on the last line. It looks the same to me.