### PR TITLE
Fix relationship in context

### DIFF
--- a/minai_plugin/contextbuilders/relationship_context.php
+++ b/minai_plugin/contextbuilders/relationship_context.php
@@ -2,6 +2,7 @@
 
 class relation {
     static function rollUpRelationshipStatus($relationshipValue) {
+        $relationshipValue = intval($relationshipValue);
         $statuses = [];
         if ($relationshipValue >= 1) {
             if ($relationshipValue >= 1) {


### PR DESCRIPTION
Make sure $relationshipValue is an int instead of a string. As it is, everyone is your "rival, foe, and enemy".

I am looking into another fix right now. Sometimes you're a stranger, so a bad value must be getting sent to the function occasionally.